### PR TITLE
Add condition for numbering show. Add region to styling.

### DIFF
--- a/simplepaper.typ
+++ b/simplepaper.typ
@@ -27,12 +27,12 @@
     #title
   ])
   set heading(numbering: "1.1")
-  set text(font: body-font, lang: "zh")
+  set text(font: body-font, lang: "zh", region: "cn")
   
   show heading: it => box(width: 100%)[
     #v(0.50em)
     #set text(font: heading-font)
-    #counter(heading).display()
+    #if it.numbering != none { counter(heading).display() }
     #h(0.75em)
     #it.body
 ]


### PR DESCRIPTION
- Numbering show condition: add this to follow the setting of the content itself. An example is when I use bib, the template forcely shows numbering for reference page. See also: https://github.com/typst/typst/discussions/1055
- Add region to support better Chinese stylings.