### PR TITLE
fix: change bibliography style to "gb-7714-2015-numeric"

### DIFF
--- a/simplepaper.typ
+++ b/simplepaper.typ
@@ -28,7 +28,7 @@
   ])
   set heading(numbering: "1.1")
   set text(font: body-font, lang: "zh", region: "cn")
-  set bibliography(style: "gb-7114-2015-numeric")
+  set bibliography(style: "gb-7714-2015-numeric")
   
   show heading: it => box(width: 100%)[
     #v(0.50em)


### PR DESCRIPTION
Typst Version:0.10.0

下载模板使用时编译报错，检查后发现是 bibliography style 有问题：

![image](https://github.com/1bitbool/SimplePaper/assets/41664195/860e2166-d8bb-4fe6-910b-9ccb7604e605)

查阅 [Cite Function](https://typst.app//docs/reference/model/cite) 文档，发现 style 项应该为 `"gb-7714-2015-numeric"`.

![image](https://github.com/1bitbool/SimplePaper/assets/41664195/1d953f17-3d80-4c9a-a650-02e5bf2e2f4b)

进一步查找发现，三周前 hayagriva 的一个 [commit](https://github.com/typst/hayagriva/commit/8ea16c61e5ae9ed2398cf245748a8bd81ebce7b0) 修复了旧版的命名错误。

![image](https://github.com/1bitbool/SimplePaper/assets/41664195/a19f92b9-1494-4b78-8ba7-00d904415f4f)
