### PR TITLE
fix: 修复 problem 函数在 Typst 0.13.0 导致的编译报错

### DIFF
--- a/simplepaper.typ
+++ b/simplepaper.typ
@@ -164,7 +164,7 @@
 #let problem-counter = counter("problem")
 #problem-counter.step()
 
-#let problem(body) = {
+#let problem(body) = context({
   problem-counter.step()
   set enum(numbering: "(1)")
   block(
@@ -173,7 +173,7 @@
     radius: 2pt,
     width: 100%,
   )[*题目 #problem-counter.display().* #h(0.75em) #body]
-}
+})
 
 #let solution(body) = {
   set enum(numbering: "(1)")


### PR DESCRIPTION
在 Typst 0.13.0 编译含有 problem 块的文件（例如 `examples/homework.typ`）会抛出下图所示错误（经测试 Typst 0.12.0 可以正常编译），此 pr 根据报错提示修复了该问题：

![图片](https://github.com/user-attachments/assets/f7ada05e-6430-419c-99fb-5ef79415b326)

```
typst c homework.typ
error: can only be used when context is known
    ┌─ simplepaper.typ:175:9
    │
175 │   )[*题目 #problem-counter.display().* #h(0.75em) #body]
    │            ^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = hint: try wrapping this in a `context` expression
    = hint: the `context` expression should wrap everything that depends on this function
```