### PR TITLE
Fix: 修复 problem 编号

### DIFF
--- a/simplepaper.typ
+++ b/simplepaper.typ
@@ -161,19 +161,19 @@
 
   body
 }
-#let problem-counter = counter("problem")
-#problem-counter.step()
 
-#let problem(body) = context({
-  problem-counter.step()
-  set enum(numbering: "(1)")
-  block(
+#let problem-counter = counter("problem")
+#let problem(body) = block(
     fill: rgb(241, 241, 255),
     inset: 8pt,
     radius: 2pt,
     width: 100%,
-  )[*题目 #problem-counter.display().* #h(0.75em) #body]
-})
+  )[
+    #problem-counter.step()
+    *题目 #context problem-counter.display().* 
+    #h(0.75em) 
+    #body
+  ]
 
 #let solution(body) = {
   set enum(numbering: "(1)")


### PR DESCRIPTION
在 https://github.com/jinhao-huang/SimplePaper/pull/12 中，`problem` 整个用 `context` 包裹貌似会导致初始编号从0开始（typst version: 0.13.1）

参考了官方文档 https://typst.app/docs/reference/introspection/counter/ 中下面的写法
```typst
#let c = counter("theorem")
#let theorem(it) = block[
  #c.step()
  *Theorem #context c.display():*
  #it
]
```

仅在 `counter.display()` 前面加上 `context` 应该才是最佳实践
